### PR TITLE
Updating the theme for QoL improvements

### DIFF
--- a/content/safespring.css
+++ b/content/safespring.css
@@ -192,7 +192,7 @@ button.md-clipboard:before {
   min-height: min-content;
 }
 
-}
+
 
 .md-clipboard:hover:before {
   color: rgba(25,95,140,1) !important;
@@ -218,8 +218,8 @@ blockquote {
 
 .md-nav__list .md-nav__list {
   color: #323232;
-  font: 400 Montserrat;
-  padding: 0;
+  font-weight: 400;
+  font-family: Montserrat;
 }
 
 .md-typeset .md-content__icon {
@@ -302,24 +302,24 @@ accent color #fa690f
 }
 
 .md-source-file:hover:before {
-  background: #fa690f:
+  background: #fa690f;
 }
 
 .md-typeset .codehilite::-webkit-scrollbar-thumb:hover {
-  background-color: #fa690f:
+  background-color: #fa690f;
 }
 
 .md-typeset .footnote li:hover .footnote-backref:hover, .md-typeset .footnote li:target .footnote-backref {
-  color: #fa690f:
+  color: #fa690f;
 }
 
 .md-typeset [id] .headerlink:focus, .md-typeset [id]:hover .headerlink:hover, .md-typeset [id]:target .headerlink {
-  color: #fa690f:
+  color: #fa690f;
 }
 
 @media only screen and (min-width:60em) {
   .md-search__scrollwrap::-webkit-scrollbar-thumb:hover {
-    background-color: #fa690f:
+    background-color: #fa690f;
   }
 }
 


### PR DESCRIPTION
After introducing the REST API page, I noticed that the Table of Contents was overflowing outside the window. This can be seen [here](https://docs.safespring.com/backup/rest-api/) when scrolling all the way down. This issue has been fixed in a newer version of the material theme, along with other quality of life improvements.

The material theme needs an update. This pull request will adjust the custom CSS file so that it becomes compatible with the latest theme version. But it wont actually update the theme, this has to be done on the server side I assume with pip.
