### PR TITLE
Backup: Fixes + Minor improvements

### DIFF
--- a/content/backup/howto/windows-recovery.md
+++ b/content/backup/howto/windows-recovery.md
@@ -114,22 +114,17 @@ System Recovery
 ---------------------
 
 1. Boot the Recovery ISO. If it was booted successfully, you should see several buttons including "Recover System", "Tools", etc.
-2. Click on "Tools".
-3. Select "Advanced Options" and hit "OK".
-4. Check "Edit Dsm.Opt". Hit "OK", and then "Close".
-5. Click on "Recover System".
-6. Optionally, you can select a location to save logs to. This can be useful for debugging potential errors. If you have a USB stick, or a volume connected to the node, you can save the logs there.
-7. Hit "Next >" three times.
-8. Fill in the following fields:
+2. Click on "Recover System".
+3. Optionally, you can select a location to save logs to. This can be useful for debugging potential errors. If you have a USB stick, or a volume connected to the node, you can save the logs there.
+4. Hit "Next >" three times.
+5. Fill in the following fields:
 
-    - Server Name/IP Address: **tsm12.backup.sto2.safedc.net**
+    - Server Name/IP Address: **server2.backup.dco1.safedc.net**
     - Port: **1600**
     - Node Name: **[Name of the Node to recover from]**
     - Password: **[Node password, can be found in Cloutility]**
     - (Optional) Point-in-time (PIT) restore: **[which point in time to restore from]** When not setting this option, TBMR will restore from the _latest_ backup.
-   
-9. Hit "Next >". Now you will be asked to apply final edits to `dsm.opt`. You have to add the line `TESTFLAG disable_tls13` to this file. Optionally, you may add other settings here if needed. Once you are done, save the file and close Notepad.
-10. Next you will be asked to specify the volume layout. A proposed one will 
+6. Next, you will be asked to specify the volume layout. A proposed one will 
     initially be provided to you, but you should definitely make sure that it 
     looks like the way you want it.
     ![Cloutility Dashboard](../images/tbmr-volume-layout.png)
@@ -139,10 +134,10 @@ System Recovery
     it means the object will be ignored. Right-click the disks and partitions 
     to specify the desired layout.
 
-11. Hit "Next >". Select the drive(s) to restore.
-12. Hit "Next >". Optionally, set network settings and machine host name.
-13. Hit "Next >". Optionally, specify the location of additional network or 
+7. Hit "Next >". Select the drive(s) to restore.
+8. Hit "Next >". Optionally, set network settings and machine host name.
+9. Hit "Next >". Optionally, specify the location of additional network or 
     storage drivers. If any additional drivers are needed, they can be provided 
     using a USB stick or a virtual volume, for example.
-14. Hit "Finish" and wait for the system to be recovered.
+10. Hit "Finish" and wait for the system to be recovered.
     ![Restoration in progress](../images/tbmr-restoring.png)

--- a/content/backup/install/linux.md
+++ b/content/backup/install/linux.md
@@ -87,7 +87,7 @@ Paste the information to the `dsm.sys` file between the `*** Copy and Paste Info
 SERVERNAME SafeDC
   *** Copy and Paste Information from Safespring Backup Portal ***
   NODENAME XXXXXXXXXX
-  TCPSERVERADDRESS tsm12.backup.sto2.safedc.net
+  TCPSERVERADDRESS server2.backup.dco1.safedc.net
   TCPPORT 1600
   *** Copy and Paste Information from Safespring Backup Portal ***
 
@@ -116,7 +116,6 @@ SERVERNAME SafeDC
   SRVPREPOSTSNAPDISABLED  yes
 
   REVOKEREMOTEACCESS Access
-  TESTFLAG disable_tls13
 ```
 
 Save both `dsm.sys` and `dsm.opt` in `/opt/tivoli/tsm/client/ba/bin/`

--- a/content/backup/quickstart-guide.md
+++ b/content/backup/quickstart-guide.md
@@ -40,6 +40,11 @@ will unconditionally make the client locally encrypt all data before transfer wi
 key you need to enter once. These two options are mutually exclusive. There is a
 None option that sets no client options from server-side.
 
+The Domain decides the retention time of your backups. 
+For example, if you choose 60DAYS, 
+then previously backed-up files will remain on the backup server for 60 days. 
+STANDARD sets the retention time to 180 days.
+
 ![Consumption Unit New Node](images/baas-portal-consumption-unit-node.png)
 
 We are recommending that you let "Data-source" be empty to let us randomize the nodename.


### PR DESCRIPTION
- Removed references to the old backup server.
- Described shortly what selecting a Domain when creating a node does.
- Removed references to the `TESTFLAG` option that was used to enforce TLS1.2. This is no longer needed. The new server is TLS1.3 compatible. References to this option may still be found in example-files, but those are hosted on [a different repo](https://raw.githubusercontent.com/safespring/cloud-BaaS/master/unix/dsm.sys.sample), and must be fixed there.