### PR TITLE
continued backfilling of security docs

### DIFF
--- a/content/compute/security-compliance/logging-monitoring.md
+++ b/content/compute/security-compliance/logging-monitoring.md
@@ -23,4 +23,6 @@ auditd runs on all hypervisors, providing full security and audit logging.
 
 ## 3.3 Time Synchronization
 
-*Information about time synchronization requirements, NTP configuration, and timestamp accuracy for audit and security purposes will be described here.*
+All servers have `systemd-timesyncd` enabled and configured to synchronize time. The timezone is set to UTC to ensure consistency across all servers.
+
+Clock drift is monitored by prometheus node exporter and alerted on when exceeding the thresholds defined in the seter site configuration: `prometheus/rules/ntp.rules`.

--- a/content/compute/security-compliance/secure-development.md
+++ b/content/compute/security-compliance/secure-development.md
@@ -4,24 +4,36 @@ This document outlines the secure development requirements and practices for Saf
 
 ## 5.1 Development Lifecycle Security
 
-*Information about secure development lifecycle processes, security requirements integration, and development security standards for compute services will be documented here.*
+Software developed for the Safespring Compute service adheres to the internal "DevOps guidelines" for secure development. The service architecture and design is defined in an internal service baseline.
+
+Otherwise Safespring relies on the upstream community for maintaining security during the development lifecycle
+
 
 ## 5.2 Application Security Requirements
 
-*Details about application security requirements, security controls, and compliance requirements for applications running on compute infrastructure will be outlined here.*
+The Safespring Compute service relies on the secured common infrastructure layer used by Safespring services and on the upstream community for defining and implementing application security requirements.
 
 ## 5.3 Secure System Architecture
 
-*Information about secure architecture principles, design patterns, and security architecture requirements for compute systems will be described here.*
+The Safespring Compute service is operated on the secured common infrastructure layer used by Safespring services. The internal `compute service baseline` defines the system architecture, automation design and forms the basis of our architecture design records(ADRs).
+
+
 
 ## 5.4 Secure Coding Standards
 
-*Details about secure coding practices, code review processes, and coding standards for compute service development will be documented here.*
+Software developed for the Safespring Compute service adheres to the internal "DevOps guidelines" for secure development.
+
+The service itself is based on Openstack, Openstack has it's own guidelines and practices. Some of those can be found in various places, including:
+
+* [contributor guidelines](https://docs.openstack.org/contributors/code-and-documentation/index.html).
+* [security guidelines](https://wiki.openstack.org/wiki/Security/Guidelines)
 
 ## 5.5 Security Testing
 
-*Information about security testing methodologies, penetration testing, vulnerability assessments, and security validation for compute services will be outlined here.*
+Software developed for the Safespring Compute service adheres to the internal "DevOps guidelines" for secure development.
+
+Safespring does not implement any additional security testing for Openstack, instead we rely on the upstream community to provide this role.
 
 ## 5.6 Outsourced Development
 
-*Details about security requirements for outsourced development, third-party security assessments, and vendor security management for compute services will be described here.*
+Safespring does not currently outsource any development work for the compute services other than relying on the upstream community for Openstack development.

--- a/content/compute/security-compliance/system-protection-maintenance.md
+++ b/content/compute/security-compliance/system-protection-maintenance.md
@@ -8,11 +8,32 @@ This document outlines the system protection and maintenance requirements and pr
 
 ## 1.2 Vulnerability Management
 
-*Details about vulnerability assessment, patch management, and security updates for compute infrastructure will be outlined here.*
+Security patches are installed automatically using the Ubuntu unattended upgrades feature.
+A high level inventory of software assets is maintained using our Netbox instance. Versions of major components are automatically registered and maintained using the `ansible/roles/SBOM` role.
+
+The compute service team monitors various data sources for security alerts and advisories.
+These and more data sources are monitored:
+
+* [Ubuntu CVE reports](https://ubuntu.com/security/cves)
+* [NIST NVD](https://nvd.nist.gov/)
+* [Opensource Vulnerability Database](https://osv.dev/list)
+
+Critical patches are applied within 7 days of release. Non-critical patches are applied within 30 days of release.
+
+Generally critical patches are applied within 24-48 hours of release. An emergency maintenance window will be scheduled when needed.
+
 
 ## 1.3 Configuration Management
 
-*Information about secure configuration standards, baseline configurations, and configuration drift detection for compute services will be described here.*
+The internal `compute service baseline` defines the system architecture, automation design and forms the basis of our architecture design records(ADRs).
+
+Based on this baseline the service automation is implemented using Ansible. All configuration changes are tracked and approved using a GitOps workflow, see [#change management in Development and Operations](development-operations-management.md#62-change-management).
+
+Ansible roles and default settings are captured in the `ansible/roles` internal repository/path. Inventory data is stored in the `seter/inventory` internal repository/path.
+
+Sensitive values and credentials are stored inside the `seter` repository, they are encrypted using a SOPS keyring. The SOPS keyring itself is protected by GPG keys from compute team members, the GPG keys are backed by yubikeys. When credentials for a component are missing, the component will fail at deployment. This ensures possible default credentials set in the roles are always overwritten.
+
+Each site has it's own private SSH keypair and GPG key. Those are used for automating deployments and configuration changes. The site keys are rotated regularly.
 
 ## 1.4 Cryptography
 

--- a/content/security-compliance/index.md
+++ b/content/security-compliance/index.md
@@ -14,7 +14,7 @@ Our internal 'DevOps Guidelines' are the reference material for all our services
 
 ## FR2000 certified
 
-Safespring is currently FR200 certified.
+Safespring is currently FR200 certified. FR2000 combines requirements from ISO 9001 (quality), ISO 14001 (environment), ISO 45001 (work environment), ISO 27001 (information security), and systematic fire safety. This means customers benefit from a holistic approach where quality, security, sustainability, and safety are all managed within one framework. Customers can trust that products and services are delivered according to well-defined processes, minimizing risks of errors, delays, or inconsistencies. Continuous improvement is built into the system, ensuring ongoing enhancements in quality and efficiency.
 
 ## ISO 27001 certification process
 


### PR DESCRIPTION
This largely finishes the backfilling of security related docs for the compute service. Still missing is security monitoring and malware prevention. The malware prevention implementation itself is still in progress.

Security monitoring is largely implemented but needs to be described in a common sections since it overlaps between infrastructure, compute and storage, leaving them as todo for now.