### PR TITLE
Update Swedish mirror description to cover Norwegian data centers

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -1657,6 +1657,7 @@ passwordexpired
 propertytype
 pswindowsupdate
 rebootpending
+wurebootstatus
 securestring
 securityprotocol
 securityprotocoltype

--- a/content/compute/howto/cloud-init.md
+++ b/content/compute/howto/cloud-init.md
@@ -201,8 +201,7 @@ try {
     Write-Host "NetBird network joined."
 
     # Reboot if required by Windows Update
-    $rebootPending = (Get-WmiObject -Class Win32_ComputerSystem).RebootPending
-    if ($rebootPending) {
+    if (Get-WURebootStatus -Silent) {
         Write-Host "Reboot required, restarting."
         Restart-Computer -Force
     }


### PR DESCRIPTION
## Summary

- Updated the Swedish mirror snippet description to say "Swedish or Norwegian data centers" instead of "Stockholm and Sundsvall regions", making it accurate for all Safespring locations.