### PR TITLE
Revise service availability table

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -20,14 +20,15 @@ in the Oslo region,
 *sto1* and *sto2* at two different locations in the Stockholm region,
 and *dco1* in Kalix.
 
-|                                  | osl2  | sto1  | sto2  | dco1  |
-|:---------------------------------|:-----:|:-----:|:-----:|:-----:|
-| Safespring Compute               |   X   |   X   |   X   |   -   |
-| Safespring Storage               |   X   |   X   |   X   |   -   |
-| Safespring Archive               |   -   |   -   |   X   |   -   |
-| Safespring Backup                |   -   |   -   |   -   |   X   |
-| Safespring on-demand Kubernetes  |   X   |   -   |   X   |   -   |
+| Service                         | osl2 | sto1 | sto2 | dco1 |
+| :------------------------------ | :--: | :--: | :--: | :--: |
+| Safespring Compute              |  X   |  X   |  X   |  -   |
+| Safespring Storage              |  X   |  X   |  X   |  -   |
+| Safespring Archive              |  -   |  -   |  X   |  -   |
+| Safespring Backup               |  X*  |  X*  |  X*  |  X   |
+| Safespring Kubernetes Engine    |  X   |  -   |  X   |  -   |
 
+* The Backup service is accessible from all data centers, but the data is stored off-site for geographic redundancy purposes.
 
 ### Safespring Compute
 


### PR DESCRIPTION
Change initiated by Rob McCuaig: Updated the service availability table and added a note about the Backup service's accessibility and data storage.

The introduction of the `X*` notation clarifies that the Backup service is available from all locations, even though backup data is not stored within the same data center. This distinction helps avoid confusion between service accessibility and data residency.