### PR TITLE
Rename on-demand Kubernetes to Safespring Kubernetes Engine (SKE)

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -1420,6 +1420,7 @@ simplebusinessunit
 simplescalable
 singlesignonurl
 sizemegabytes
+ske
 skippublishercheck
 sktxlg
 sla

--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -49,6 +49,7 @@ aggregationlength
 agreedlegalterms
 ahkfjpgewxzelmakga
 aj
+ake
 alertmanager
 alertmanagerspec
 alertname
@@ -198,6 +199,7 @@ capicmd
 catched
 cbb
 cbmr
+ccm
 cdn
 cdromdevice
 cdxgen
@@ -455,6 +457,7 @@ eba
 ebd
 ebpf
 ecc
+ecdhe
 ecmp
 eea
 eedd
@@ -691,6 +694,7 @@ ifjvb
 ignorepublicacls
 ignorereboot
 ignoretotp
+iis
 imagename
 imagepullbackoff
 img

--- a/content/compute/gpu.md
+++ b/content/compute/gpu.md
@@ -141,4 +141,4 @@ Open `http://localhost:8080` in your browser to access the chat interface. All p
 
 ## GPU in Kubernetes
 
-If you are using Safespring's On-demand Kubernetes service, GPU support is available through worker nodes with GPU flavors. See the [Kubernetes GPU documentation](../kubernetes/gpu.md) for details on how to use GPUs in Kubernetes workloads.
+If you are using Safespring Kubernetes Engine, GPU support is available through worker nodes with GPU flavors. See the [Kubernetes GPU documentation](../kubernetes/gpu.md) for details on how to use GPUs in Kubernetes workloads.

--- a/content/compute/image.md
+++ b/content/compute/image.md
@@ -20,7 +20,7 @@ Safespring provides the following public images:
 | `windows-server-2022` | Windows Server 2022 |
 | `cirros` | Minimal test image, not for production use |
 
-The `talos-image-*` images are used internally by the [On-demand Kubernetes](../kubernetes/getting-started.md) service and are not intended for direct use.
+The `talos-image-*` images are used internally by [Safespring Kubernetes Engine](../kubernetes/getting-started.md) and are not intended for direct use.
 
 !!! warning "CirrOS is for testing only"
     The CirrOS image is a minimal Linux distribution designed for testing cloud infrastructure. It should not be used for production workloads.

--- a/content/index.md
+++ b/content/index.md
@@ -43,9 +43,9 @@ information](storage/getting-started.md)
 To get started with the Backup service,
 see the [quickstart guide](backup/quickstart-guide.md)
 
-### Safespring Kubernetes Engine
+### Safespring Kubernetes Engine (SKE)
 
-To get started with Safespring Kubernetes Engine,
+To get started with SKE,
 we have a page with [general information](kubernetes/getting-started.md)
 
 ## Roadmap
@@ -55,15 +55,15 @@ This section describes what we are working on right now
 ### 1 - 3 months
 
 * MFA features in Openstack for public cloud
-* Safespring Kubernetes Engine load balancing improvements (retain source IP address)
-* Private cloud Safespring Kubernetes Engine
+* SKE load balancing improvements (retain source IP address)
+* Private cloud SKE
 
 ## Recent changes in the platform
 
 ### 2026 Q1
 
 * STO1 migrated to new hardware, refreshed core network and major upgrades to Openstack
-* Introduced Safespring Kubernetes Engine and self-service portal
+* Introduced SKE and self-service portal
 * H100 flavors in STO1 on request
 
 

--- a/content/index.md
+++ b/content/index.md
@@ -26,7 +26,7 @@ and *dco1* in Kalix.
 | Safespring Storage               |   X   |   X   |   X   |   -   |
 | Safespring Archive               |   -   |   -   |   X   |   -   |
 | Safespring Backup                |   -   |   -   |   -   |   X   |
-| Safespring on-demand Kubernetes  |   X   |   -   |   X   |   -   |
+| Safespring Kubernetes Engine     |   X   |   -   |   X   |   -   |
 
 
 ### Safespring Compute
@@ -43,9 +43,9 @@ information](storage/getting-started.md)
 To get started with the Backup service,
 see the [quickstart guide](backup/quickstart-guide.md)
 
-### Safespring on-demand Kubernetes
+### Safespring Kubernetes Engine
 
-To get started with the on-demand Kubernetes service,
+To get started with Safespring Kubernetes Engine,
 we have a page with [general information](kubernetes/getting-started.md)
 
 ## Roadmap
@@ -55,15 +55,15 @@ This section describes what we are working on right now
 ### 1 - 3 months
 
 * MFA features in Openstack for public cloud
-* On-demand Kubernetes loadbalancing improvements (retain source ip address)
-* Private cloud on-demand Kubernetes
+* Safespring Kubernetes Engine load balancing improvements (retain source IP address)
+* Private cloud Safespring Kubernetes Engine
 
 ## Recent changes in the platform
 
 ### 2026 Q1
 
 * STO1 migrated to new hardware, refreshed core network and major upgrades to Openstack
-* Introduced on-demand Kubernetes and self-service portal
+* Introduced Safespring Kubernetes Engine and self-service portal
 * H100 flavors in STO1 on request
 
 

--- a/content/kubernetes/getting-started.md
+++ b/content/kubernetes/getting-started.md
@@ -1,10 +1,10 @@
-# Getting Started with on-demand Kubernetes
+# Getting Started with Safespring Kubernetes Engine
 
-This guide will help you get started with Safespring's on-demand Kubernetes service.
+This guide will help you get started with Safespring Kubernetes Engine.
 
 ## Overview
 
-On-demand Kubernetes allows users to create, scale and use Kubernetes clusters. Such a functionality is made available through a [portal and API](portal-overview.md), where users can manage the clusters.
+Safespring Kubernetes Engine allows users to create, scale and use Kubernetes clusters. This functionality is made available through a [portal and API](portal-overview.md), where users can manage the clusters.
 
 It is built on top of the [Safespring Compute](../compute/getting-started.md) service.
 
@@ -57,10 +57,10 @@ Currently all available storage classes are based on networked storage.
 
 ## SLA and Availability
 
-Safespring on-demand Kubernetes is a highly available, reliable Kubernetes service.
-The clusters provisioned have a managed control plane with a 99.5% uptime SLA measured against the kubernetes API availability.
+Safespring Kubernetes Engine is a highly available, reliable Kubernetes service.
+The clusters provisioned have a managed control plane with a 99.5% uptime SLA measured against the Kubernetes API availability.
 
-The worker nodes that are part of the cluster are part of the default Compute service SLA and not included in the on-demand Kubernetes SLA.
+The worker nodes that are part of the cluster are part of the default Compute service SLA and not included in the Safespring Kubernetes Engine SLA.
 
 For any questions regarding the SLA please reach out to [support](../service/support.md).
 

--- a/content/kubernetes/getting-started.md
+++ b/content/kubernetes/getting-started.md
@@ -1,10 +1,10 @@
 # Getting Started with Safespring Kubernetes Engine
 
-This guide will help you get started with Safespring Kubernetes Engine.
+This guide will help you get started with Safespring Kubernetes Engine (SKE).
 
 ## Overview
 
-Safespring Kubernetes Engine allows users to create, scale and use Kubernetes clusters. This functionality is made available through a [portal and API](portal-overview.md), where users can manage the clusters.
+SKE allows users to create, scale and use Kubernetes clusters. This functionality is made available through a [portal and API](portal-overview.md), where users can manage the clusters.
 
 It is built on top of the [Safespring Compute](../compute/getting-started.md) service.
 
@@ -57,10 +57,10 @@ Currently all available storage classes are based on networked storage.
 
 ## SLA and Availability
 
-Safespring Kubernetes Engine is a highly available, reliable Kubernetes service.
+SKE is a highly available, reliable Kubernetes service.
 The clusters provisioned have a managed control plane with a 99.5% uptime SLA measured against the Kubernetes API availability.
 
-The worker nodes that are part of the cluster are part of the default Compute service SLA and not included in the Safespring Kubernetes Engine SLA.
+The worker nodes that are part of the cluster are part of the default Compute service SLA and not included in the SKE SLA.
 
 For any questions regarding the SLA please reach out to [support](../service/support.md).
 

--- a/content/kubernetes/gpu.md
+++ b/content/kubernetes/gpu.md
@@ -1,6 +1,6 @@
 # Making use of GPU
 
-In order to make use of GPU, one must add or already have worker nodes with [GPU flavors](../compute/flavors.md). Currently this means you can only use On-demand Kubernetes clusters in STO2 that have worker nodes with flavors that are suffixed with `gA2`.
+In order to make use of GPU, one must add or already have worker nodes with [GPU flavors](../compute/flavors.md). Currently this means you can only use Safespring Kubernetes Engine clusters in STO2 that have worker nodes with flavors that are suffixed with `gA2`.
 
 Given that we use Talos Linux, we cannot make use of [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html) and instead we install [NVIDIA device plugin for Kubernetes](https://github.com/NVIDIA/k8s-device-plugin).
 

--- a/content/kubernetes/persistent-volumes.md
+++ b/content/kubernetes/persistent-volumes.md
@@ -4,7 +4,7 @@ Container filesystems are ephemeral by default, meaning they reset after an appl
 
 Consider the following:
 
-- It makes use of [Cinder CSI](getting-started.md#additional-components) activated on your Safespring on-demand Kubernetes by default;
+- It makes use of [Cinder CSI](getting-started.md#additional-components) activated on your Safespring Kubernetes Engine by default;
 - **Size:** Can be expanded, but not reduced;
 - **StorageClass:** Represents the "kind" of storage which are equivalent to the storage classes available on [OpenStack Volume types](../compute/flavors.md);
 - **AccessMode:** Typically, only one pod can mount a given PVC at a time, though some storage classes allow multiple pods to access it simultaneously.

--- a/content/kubernetes/secret-management.md
+++ b/content/kubernetes/secret-management.md
@@ -1,6 +1,6 @@
 # Secret Management
 
-Whilst secrets inside Safespring On-demand Kubernetes are [encrypted at rest](security-compliance/index.md#secrets-management) the ecosystem of secret management inside a Kubernetes cluster is diverse with solutions each with various features, for example:
+Whilst secrets inside Safespring Kubernetes Engine are [encrypted at rest](security-compliance/index.md#secrets-management), the ecosystem of secret management inside a Kubernetes cluster is diverse, with solutions each offering various features, for example:
 
 - [Kubernetes external secrets](https://github.com/external-secrets/external-secrets)
 - [Vault Secrets Operator](https://github.com/ricoberger/vault-secrets-operator) with [OpenBao](https://openbao.org/docs/platform/k8s/) OSS alternative

--- a/content/kubernetes/security-compliance/data-management.md
+++ b/content/kubernetes/security-compliance/data-management.md
@@ -1,6 +1,6 @@
 # Data Management
 
-This document outlines the data management requirements and practices for Safespring on-demand Kubernetes services.
+This document outlines the data management requirements and practices for Safespring Kubernetes Engine.
 
 ## 2.1 Data Retention and Deletion
 
@@ -10,7 +10,7 @@ After contract expiration, Safespring will delete any leftover data associated w
 
 ## 2.2 Backup and Recovery
 
-Automatic backups are created of the management infrastructure: control-plane etcd, as well as [Zitadel IAM](https://zitadel.com/) database, Safespring on-demand Kubernetes Load-balancer as well as the [Harbor Registry](https://goharbor.io/) database.
+Automatic backups are created of the management infrastructure: control-plane etcd, as well as [Zitadel IAM](https://zitadel.com/) database, Safespring Kubernetes Engine Load-balancer as well as the [Harbor Registry](https://goharbor.io/) database.
 
 Regular restore tests are done during upgrades and during disaster recovery simulations.
 

--- a/content/kubernetes/security-compliance/data-management.md
+++ b/content/kubernetes/security-compliance/data-management.md
@@ -1,6 +1,6 @@
 # Data Management
 
-This document outlines the data management requirements and practices for Safespring Kubernetes Engine.
+This document outlines the data management requirements and practices for Safespring Kubernetes Engine (SKE).
 
 ## 2.1 Data Retention and Deletion
 
@@ -10,7 +10,7 @@ After contract expiration, Safespring will delete any leftover data associated w
 
 ## 2.2 Backup and Recovery
 
-Automatic backups are created of the management infrastructure: control-plane etcd, as well as [Zitadel IAM](https://zitadel.com/) database, Safespring Kubernetes Engine Load-balancer as well as the [Harbor Registry](https://goharbor.io/) database.
+Automatic backups are created of the management infrastructure: control-plane etcd, as well as [Zitadel IAM](https://zitadel.com/) database, SKE Load-balancer as well as the [Harbor Registry](https://goharbor.io/) database.
 
 Regular restore tests are done during upgrades and during disaster recovery simulations.
 

--- a/content/kubernetes/security-compliance/development-operations-management.md
+++ b/content/kubernetes/security-compliance/development-operations-management.md
@@ -1,10 +1,10 @@
 # Development and Operations Management
 
-This document outlines the development and operations management requirements and practices for Safespring on-demand Kubernetes services.
+This document outlines the development and operations management requirements and practices for Safespring Kubernetes Engine.
 
 ## 6.1 Environment Separation
 
-Safespring On-Demand Kubernetes operational infrastructure is currently divided into two types of clusters:
+Safespring Kubernetes Engine operational infrastructure is currently divided into two types of clusters:
 
 - Ops Cluster - necessary for having a centralized view (logging, monitoring) of the infrastructure and the operations performed on it, as well as acting as the controller (via ArgoCD) for application setup both in Ops Cluster as well as Management Cluster(s);
 - Management Cluster(s) - needs to be at least 1 per [datacenter](../../index.md#services) (e.g. osl2, sto2 etc.) with the purpose of acting as both the Management cluster for creating Workload Clusters, as well as any necessary site specific components for enabling cluster creation and monitoring.
@@ -17,7 +17,7 @@ The dedicated staging environment that runs within the same production security 
 
 The testing environment is used for CI/CD, upgrade testing, bug fixing, etc.
 
-Customer data from the on-demand Kubernetes service is never transferred to other environments than the production environment.
+Customer data from Safespring Kubernetes Engine is never transferred to other environments than the production environment.
 
 ## 6.2 Change Management
 

--- a/content/kubernetes/security-compliance/development-operations-management.md
+++ b/content/kubernetes/security-compliance/development-operations-management.md
@@ -1,23 +1,23 @@
 # Development and Operations Management
 
-This document outlines the development and operations management requirements and practices for Safespring Kubernetes Engine.
+This document outlines the development and operations management requirements and practices for Safespring Kubernetes Engine (SKE).
 
 ## 6.1 Environment Separation
 
-Safespring Kubernetes Engine operational infrastructure is currently divided into two types of clusters:
+SKE operational infrastructure is currently divided into two types of clusters:
 
 - Ops Cluster - necessary for having a centralized view (logging, monitoring) of the infrastructure and the operations performed on it, as well as acting as the controller (via ArgoCD) for application setup both in Ops Cluster as well as Management Cluster(s);
 - Management Cluster(s) - needs to be at least 1 per [datacenter](../../index.md#services) (e.g. osl2, sto2 etc.) with the purpose of acting as both the Management cluster for creating Workload Clusters, as well as any necessary site specific components for enabling cluster creation and monitoring.
 
-We also make use of 3 types environments: testing (including CI/CD), staging/QA and production.
+We also make use of 3 types of environments: testing (including CI/CD), staging/QA and production.
 
 Customers always run their Workload Clusters from the production Management Clusters.
 
-The dedicated staging environment that runs within the same production security measures as the production environments.
+The dedicated staging environment runs within the same production security measures as the production environments.
 
 The testing environment is used for CI/CD, upgrade testing, bug fixing, etc.
 
-Customer data from Safespring Kubernetes Engine is never transferred to other environments than the production environment.
+Customer data from SKE is never transferred to other environments than the production environment.
 
 ## 6.2 Change Management
 

--- a/content/kubernetes/security-compliance/index.md
+++ b/content/kubernetes/security-compliance/index.md
@@ -1,10 +1,10 @@
 # Security and Compliance
 
-This chapter covers security and compliance aspects specific to Safespring on-demand Kubernetes services.
+This chapter covers security and compliance aspects specific to Safespring Kubernetes Engine.
 
 ## Overview
 
-Safespring’s on-demand Kubernetes services are designed with security and compliance as core principles. The platform leverages modern, immutable infrastructure with **Talos Linux**, enforces **policy-driven governance with Kyverno**, ensures **supply chain integrity with GitOps and age-encrypted secrets**, provides **identity and access management through Zitadel with RBAC and MFA**, and offers **observability and compliance monitoring through Grafana and Kubescape**.
+Safespring Kubernetes Engine is designed with security and compliance as core principles. The platform leverages modern, immutable infrastructure with **Talos Linux**, enforces **policy-driven governance with Kyverno**, ensures **supply chain integrity with GitOps and age-encrypted secrets**, provides **identity and access management through Zitadel with RBAC and MFA**, and offers **observability and compliance monitoring through Grafana and Kubescape**.
 
 The following sections detail the different layers of security and compliance.
 

--- a/content/kubernetes/security-compliance/index.md
+++ b/content/kubernetes/security-compliance/index.md
@@ -1,10 +1,10 @@
 # Security and Compliance
 
-This chapter covers security and compliance aspects specific to Safespring Kubernetes Engine.
+This chapter covers security and compliance aspects specific to Safespring Kubernetes Engine (SKE).
 
 ## Overview
 
-Safespring Kubernetes Engine is designed with security and compliance as core principles. The platform leverages modern, immutable infrastructure with **Talos Linux**, enforces **policy-driven governance with Kyverno**, ensures **supply chain integrity with GitOps and age-encrypted secrets**, provides **identity and access management through Zitadel with RBAC and MFA**, and offers **observability and compliance monitoring through Grafana and Kubescape**.
+SKE is designed with security and compliance as core principles. The platform leverages modern, immutable infrastructure with **Talos Linux**, enforces **policy-driven governance with Kyverno**, ensures **supply chain integrity with GitOps and age-encrypted secrets**, provides **identity and access management through Zitadel with RBAC and MFA**, and offers **observability and compliance monitoring through Grafana and Kubescape**.
 
 The following sections detail the different layers of security and compliance.
 

--- a/content/kubernetes/security-compliance/logging-monitoring.md
+++ b/content/kubernetes/security-compliance/logging-monitoring.md
@@ -1,16 +1,16 @@
 # Logging and Monitoring
 
-This document outlines the logging and monitoring requirements and practices for Safespring Kubernetes Engine.
+This document outlines the logging and monitoring requirements and practices for Safespring Kubernetes Engine (SKE).
 
 ## 3.1 System Logging
 
-Logs are collected per site in a shared logging system using[grafana Loki](https://grafana.com/oss/loki/). The service runs on the operations cluster and monitor applications and clusters on each site.The infrastructure and configuration is fully automated using our internal git repositories and ArgoCD.
+Logs are collected per site in a shared logging system using [Grafana Loki](https://grafana.com/oss/loki/). The service runs on the operations cluster and monitors applications and clusters on each site. The infrastructure and configuration is fully automated using our internal git repositories and ArgoCD.
 
 API and application logs can be provided to the customer on a case by case basis. Please request access through support, and include the site and relevant access IDs.
 
-!!! note "Safespring Kubernetes Engine Logs"
+!!! note "SKE Logs"
 
-    For Safespring Kubernetes Engine clusters we do not store or monitor the logs.
+    For SKE clusters we do not store or monitor the logs.
 
 ## 3.2 Security Monitoring
 

--- a/content/kubernetes/security-compliance/logging-monitoring.md
+++ b/content/kubernetes/security-compliance/logging-monitoring.md
@@ -1,6 +1,6 @@
 # Logging and Monitoring
 
-This document outlines the logging and monitoring requirements and practices for Safespring on-demand Kubernetes services.
+This document outlines the logging and monitoring requirements and practices for Safespring Kubernetes Engine.
 
 ## 3.1 System Logging
 
@@ -8,9 +8,9 @@ Logs are collected per site in a shared logging system using[grafana Loki](https
 
 API and application logs can be provided to the customer on a case by case basis. Please request access through support, and include the site and relevant access IDs.
 
-!!! note "On-demand Kubernetes Logs"
+!!! note "Safespring Kubernetes Engine Logs"
 
-    For on-demand Kubernetes clusters we do not store or monitor the logs.
+    For Safespring Kubernetes Engine clusters we do not store or monitor the logs.
 
 ## 3.2 Security Monitoring
 

--- a/content/kubernetes/security-compliance/network-security.md
+++ b/content/kubernetes/security-compliance/network-security.md
@@ -1,6 +1,6 @@
 # Network Security
 
-This document outlines the network security requirements and practices for Safespring on-demand Kubernetes services with a focus on [operational infrastructure](development-operations-management.md).
+This document outlines the network security requirements and practices for Safespring Kubernetes Engine with a focus on [operational infrastructure](development-operations-management.md).
 
 ## 4.1 Network Protection
 

--- a/content/kubernetes/security-compliance/secure-development.md
+++ b/content/kubernetes/security-compliance/secure-development.md
@@ -1,10 +1,10 @@
 # Secure Development
 
-This document outlines the secure development requirements and practices for Safespring on-demand Kubernetes services.
+This document outlines the secure development requirements and practices for Safespring Kubernetes Engine.
 
 ## 5.1 Development Lifecycle Security
 
-Applications developed for on-demand Kubernetes implement multiple layers to ensure a secure development lifecycle.
+Applications developed for Safespring Kubernetes Engine implement multiple layers to ensure a secure development lifecycle.
 
 * Development is done in stages starting with the local environment and progressing to testing and stage before getting packaged and released to production;
 * Code reviews are mandatory, access control is enforced. See [change management](development-operations-management.md#62-change-management) for implementation details;
@@ -42,4 +42,4 @@ Industry best practices and resources are used to ensure secure coding standards
 
 ## 5.6 Outsourced Development
 
-Development is never outsourced for components developed for on-demand Kubernetes service.
+Development is never outsourced for components developed for Safespring Kubernetes Engine.

--- a/content/kubernetes/security-compliance/secure-development.md
+++ b/content/kubernetes/security-compliance/secure-development.md
@@ -1,10 +1,10 @@
 # Secure Development
 
-This document outlines the secure development requirements and practices for Safespring Kubernetes Engine.
+This document outlines the secure development requirements and practices for Safespring Kubernetes Engine (SKE).
 
 ## 5.1 Development Lifecycle Security
 
-Applications developed for Safespring Kubernetes Engine implement multiple layers to ensure a secure development lifecycle.
+Applications developed for SKE implement multiple layers to ensure a secure development lifecycle.
 
 * Development is done in stages starting with the local environment and progressing to testing and stage before getting packaged and released to production;
 * Code reviews are mandatory, access control is enforced. See [change management](development-operations-management.md#62-change-management) for implementation details;
@@ -42,4 +42,4 @@ Industry best practices and resources are used to ensure secure coding standards
 
 ## 5.6 Outsourced Development
 
-Development is never outsourced for components developed for Safespring Kubernetes Engine.
+Development is never outsourced for components developed for SKE.

--- a/content/kubernetes/security-compliance/system-protection-maintenance.md
+++ b/content/kubernetes/security-compliance/system-protection-maintenance.md
@@ -1,6 +1,6 @@
 # System Protection and Maintenance
 
-This document outlines the system protection and maintenance requirements and practices for Safespring on-demand Kubernetes services.
+This document outlines the system protection and maintenance requirements and practices for Safespring Kubernetes Engine.
 
 ## 1.1 Malware Protection
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,7 +207,7 @@ nav:
       - Tips and Tricks: "storage/tips-n-tricks.md"
       - Backup Exec and Safespring Storage: "storage/backup-exec.md"
       - Other Backends: "storage/other-backends.md"
-  - On-demand Kubernetes:
+  - Safespring Kubernetes Engine:
       - Getting Started: "kubernetes/getting-started.md"
       - Portal Overview: "kubernetes/portal-overview.md"
       - Authentication: "kubernetes/authentication.md"


### PR DESCRIPTION
## Summary

Renames the product currently documented as **on-demand Kubernetes** to **Safespring Kubernetes Engine**, and introduces the **SKE** acronym.

- Renamed all product-name references (32 occurrences across 15 files), dropping redundant `Safespring`/`service` wording. Generic Kubernetes usages (e.g. "Kubernetes clusters", "Kubernetes API") were left untouched.
- Updated the `mkdocs.yml` nav entry.
- Defined `Safespring Kubernetes Engine (SKE)` on first use per page and used `SKE` thereafter, on pages that reference it more than once. Single-mention pages keep the full name.
- Added `ske` to `.github/config/.wordlist.txt` for the spell-checker.

## Incidental typo / grammar fixes

- `loadbalancing` → `load balancing`, `source ip address` → `source IP address` (index.md)
- lowercase `kubernetes API` → `Kubernetes API`; "Such a functionality" → "This functionality" (getting-started.md)
- run-on cleanup in secret-management.md
- subject-verb agreement in security-compliance/index.md
- logging intro: `using[grafana` → `using [Grafana`, `monitor` → `monitors`, missing sentence space
- `3 types environments` → `3 types of environments`; staging-environment sentence fragment (development-operations-management.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)